### PR TITLE
[Enhancement] Fix Deploy to Correct Environment & Enable Manual Trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build worker.js
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
   release:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy Worker
 on:
+  workflow_dispatch:
   repository_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,6 @@ jobs:
 
     - name: Deploy
       run: sed -i s/KV_NAME/${{ secrets.KV_NAME }}/g wrangler.toml
-      with:
+      env:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         accountId: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
This pull request addresses two issues:

**1. Incorrect Environment Deployment:**

The previous deployment logic incorrectly used the `with` keyword when determining the target environment.  This has been corrected to use the `env` keyword.

**2. Lack of Manual Trigger:**

This pull request adds the ability to manually trigger the workflow using `workflow_dispatch`.  This allows for greater control and flexibility in running the deployment process without needing the _`Deploy With Workers`_.