### PR TITLE
fix: fixed deploy_to_cf_workers workflow and others

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
@@ -21,11 +21,24 @@ jobs:
       run: npm i wrangler@latest
 
     - name: Build
-      run: npx wrangler build
+      run: npx wrangler deploy --dry-run --outdir=dist
 
     - name: Add Header
-      run: cp ${{ github.workspace }}/dist/worker.js ${{ github.workspace }}/dist/worker-original.js && echo -e "/*!\n  * v2ray Subscription Worker (${{ github.sha }})\n  * Copyright 2024 Vahid Farid (https://twitter.com/vahidfarid)\n  * Licensed under GPLv3 (https://github.com/vfarid/v2ray-worker/blob/main/Licence.md)\n  */\n\n$(cat ${{ github.workspace }}/dist/worker.js)" > ${{ github.workspace }}/dist/worker.js
+      run: |
+        cp ${{ github.workspace }}/dist/worker.js ${{ github.workspace }}/dist/worker-original.js \
+        && echo -e \
+        "/*!
+          * v2ray Subscription Worker (${{ github.sha }})
+          * Copyright 2024 Vahid Farid (https://twitter.com/vahidfarid)
+          * Licensed under GPLv3 (https://github.com/vfarid/v2ray-worker/blob/main/Licence.md)
+          */
+
+        $(cat ${{ github.workspace }}/dist/worker.js)" > ${{ github.workspace }}/dist/worker.js
 
     - name: Deploy
-      run: sed -i "s/KV_NAME/{{ secrets.KV_NAME }}/g" wrangler.toml && wrangler deploy --api-token ${{ secrets.CF_API_TOKEN }} --account-id ${{ secrets.CF_ACCOUNT_ID }}
-
+      run: |
+        sed -i "s/V2RAY_WORKER_KV_ID/${{ secrets.V2RAY_WORKER_KV_ID }}/g" wrangler.toml \
+        && npx wrangler deploy
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -1,0 +1,21 @@
+# V2Ray Worker
+通过 Cloudflare Workers 配置 V2Ray 的一站式解决方案
+
+[English version](https://github.com/vfarid/v2ray-worker/blob/main/README.md)
+[نسخه فارسی](https://github.com/vfarid/v2ray-worker/blob/main/README-fa.md)
+
+## 如何使用
+
+待补充……
+
+## 部署
+1. 复刻这个仓库并启用 Github Action
+2. 进入 [Cloudflare 仪表板](https://dash.cloudflare.com)，在“存储和数据库 / KV”下创建命名空间 `v2ray_worker_settings`，并复制其 ID
+3. 进入复刻的仓库，在“Settings / Secrets and variables / Actions”中设置新的 secret，名称为 `V2RAY_WORKER_KV_ID`，值为上一步复制的 KV `v2ray_worker_settings` ID
+4. 修改 `README.md`，找到下方的按钮，将最后的 url 修改为你自己复刻的仓库链接 `https://github.com/USER/REPO_NAME` 并保存
+5. 点击 `Deploy With Workers`，跟随指引进行配置
+
+### Credits
+Built-in vless config generator is based on [Zizifn Edge Tunnel](https://github.com/zizifn/edgetunnel), re-written using Typescript.
+Built-in trojan config generator is based on [ca110us/epeius](https://github.com/ca110us/epeius/tree/main), re-written using Typescript.
+Proxy IPs source: https://rentry.co/CF-proxyIP

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # V2Ray Worker
- Total solution for v2ray configs over Cloudflare's worker
+Total solution for v2ray configs over Cloudflare's worker
 
 [نسخه فارسی](https://github.com/vfarid/v2ray-worker/blob/main/README-fa.md)
 
@@ -7,10 +7,10 @@
 
 To be completed...
 
-## Deploy 
+## Deploy
  1. Fork this Repo and enable Github Action
- 2. Open CloudFlare and create KV namespace with name `settings` then copy the ID
- 3. Go to this forked repo and set secrets with name `KV_NAME` and fill with KV settings ID
+ 2. Open CloudFlare and create KV namespace with name `v2ray_worker_settings` then copy the ID
+ 3. Go to this forked repo and set secrets with name `V2RAY_WORKER_KV_ID` and fill with KV `v2ray_worker_settings` ID
  4. Edit this `README.md` file, then find and replace this button url bellow with yours `https://github.com/USER/REPO_NAME` then save it.
  4. then press `Deploy With Workers` and follow the instruction
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 Total solution for v2ray configs over Cloudflare's worker
 
 [نسخه فارسی](https://github.com/vfarid/v2ray-worker/blob/main/README-fa.md)
+[简体中文](https://github.com/vfarid/v2ray-worker/blob/main/README-zh-CN.md)
 
 ## How to use
 
 To be completed...
 
 ## Deploy
- 1. Fork this Repo and enable Github Action
- 2. Open CloudFlare and create KV namespace with name `v2ray_worker_settings` then copy the ID
- 3. Go to this forked repo and set secrets with name `V2RAY_WORKER_KV_ID` and fill with KV `v2ray_worker_settings` ID
- 4. Edit this `README.md` file, then find and replace this button url bellow with yours `https://github.com/USER/REPO_NAME` then save it.
- 4. then press `Deploy With Workers` and follow the instruction
+1. Fork this Repo and enable Github Action
+2. Open [Cloudflare dashboard](https://dash.cloudflare.com), navigate to Storage & Databases / KV, and create KV namespace with name `v2ray_worker_settings` then copy the ID
+3. Go to this forked repo and set secrets with name `V2RAY_WORKER_KV_ID` and fill with KV `v2ray_worker_settings` ID
+4. Edit this `README.md` file, then find and replace this button url bellow with yours `https://github.com/USER/REPO_NAME` then save it
+5. then press `Deploy With Workers` and follow the instruction
 
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/vfarid/v2ray-worker)
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,8 +1,8 @@
 name = "sub"
 main = "src/worker.ts"
-compatibility_date = "2024-05-29"
+compatibility_date = "2025-02-18"
 compatibility_flags = ["nodejs_compat"]
 
 kv_namespaces = [
-  { binding = "settings", id = "KV_NAME" }
+  { binding = "v2ray_worker_settings", id = "V2RAY_WORKER_KV_ID" }
 ]


### PR DESCRIPTION
## Overview of the problem

Wrangler has dropped support of flag `--api-token` and `--account-id`. And the current workflow also has the problem that `sed` not substituding with secret, and using global `wrangler` instead of `npx wrangler`.

This PR only resolves the deployment problem, and doesn't resolve Worker 1011 problem.

## Changes

The major change is changing `wrangler deploy` to `npx wrangler deploy` (problem of #93) and adding the missing variable reference `${{ secrets.KV_NAME }}`.

I've also removed no longer supported `--api-token` and `--account-id` and uses variables `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` instead.

```diff
-    - name: Deploy
-      run: sed -i "s/KV_NAME/{{ secrets.KV_NAME }}/g" wrangler.toml && wrangler deploy --api-token ${{ secrets.CF_API_TOKEN }} --account-id ${{ secrets.CF_ACCOUNT_ID }}
+    - name: Deploy
+      run: |
+        sed -i "s/V2RAY_WORKER_KV_ID/${{ secrets.V2RAY_WORKER_KV_ID }}/g" wrangler.toml \
+        && npx wrangler deploy
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
```

Some other changes of this PR:

- improved and provided with a zh_CN version of README.md
- edited `wrangler.toml`
  - use a more semantic namespace `v2ray_worker_settings`
  - changed `KV_NAME` to `V2RAY_WORKER_KV_ID`
  - bumped `compatibility_date`

## Notes

Please be cautious that I haven't tested the deployed worker yet. If there's any compability issues related to Cloudflare API compatiblity date just revert that line of code back to `compatibility_date = "2024-05-29"`.

The `README-fa.md` is also not updated.